### PR TITLE
TEF-1011 TEF-1219 Setting the Sandbox SSL version to TLSv1 is not needed anymore

### DIFF
--- a/lib/vsafe/client.rb
+++ b/lib/vsafe/client.rb
@@ -88,12 +88,6 @@ module VSafe
         logger: @config.logger
       }
 
-      # The HTTPS endpoint for VSafe Sandbox has an outdated SSL version.
-      # We need to do this so that we can actually connect.
-      if config.sandbox
-        options[:ssl_version] = :TLSv1
-      end
-
       HTTParty.post(url, options)
     end
   end

--- a/lib/vsafe/version.rb
+++ b/lib/vsafe/version.rb
@@ -1,3 +1,3 @@
 module VSafe
-  VERSION = "0.2.5"
+  VERSION = "0.2.6"
 end


### PR DESCRIPTION
currently, on sandbox env returns:
```#<OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=unknown state: sslv3 alert handshake failure>```

as part of:
https://juvomobile.atlassian.net/browse/TEF-1011 
and
https://juvomobile.atlassian.net/browse/TEF-1219